### PR TITLE
FEATURE setduration 기간설정 API

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -52,6 +52,7 @@ CUSTOM_APPS = [
     "medias.apps.MediasConfig",
     "petitions.apps.PetitionsConfig",
     "surveys.apps.SurveysConfig",
+    "setdurations.apps.SetdurationsConfig",
     "users.apps.UsersConfig",
 ]
 

--- a/backend/setdurations/admin.py
+++ b/backend/setdurations/admin.py
@@ -1,3 +1,14 @@
 from django.contrib import admin
+from .models import SetDurations
 
-# Register your models here.
+@admin.register(SetDurations)
+class SetDurations(admin.ModelAdmin):
+    list_display = (
+        "kind",
+        "writer",
+        "survey",
+        "start_date",
+        "end_date",
+        "in_a_day_date",
+    )
+    list_filter = ("kind",)

--- a/backend/setdurations/models.py
+++ b/backend/setdurations/models.py
@@ -1,3 +1,46 @@
 from django.db import models
+from common.models import CommonModel
 
-# Create your models here.
+class SetDurations(CommonModel):
+
+    """For Survey Period"""
+
+    class ApplyModelKindChoices(models.TextChoices):
+        SURVEY = "survey", "설문 조사"
+
+    kind = models.CharField(
+        max_length=15,
+        choices=ApplyModelKindChoices.choices,
+    )
+
+    writer = models.ForeignKey(
+        "users.User",
+        on_delete=models.CASCADE,
+        related_name="set_durations",
+    )
+
+    survey = models.ForeignKey(
+        "surveys.Survey",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="set_durations",
+    )
+
+    start_date= models.DateField(
+        null=True,
+        blank=True,
+    )
+
+    end_date= models.DateField(
+        null=True,
+        blank=True,
+    )
+
+    in_a_day_date=models.DateField(
+        null=True,
+        blank=True,
+    )
+
+    def __str__(self):
+        return f"{self.user}이 생성한 {self.kind.title()}"

--- a/backend/setdurations/serializers.py
+++ b/backend/setdurations/serializers.py
@@ -1,0 +1,47 @@
+from django.utils import timezone
+from rest_framework import serializers
+from .models import SetDurations
+
+
+class CreateSurveySerializer(serializers.ModelSerializer):
+
+    start_date = serializers.DateField()
+    end_date = serializers.DateField()
+
+    class Meta:
+        model = SetDurations
+        fields = (
+            "start_date",
+            "end_date",
+        )
+
+    def validate_start_date(self, value):
+        now = timezone.localtime(timezone.now()).date()
+        if now > value:
+            raise serializers.ValidationError("지나간 날부터 설문조사 시작일자 설정을 할 수 없습니다.")
+        return value
+
+    def validate_end_date(self, value):
+        now = timezone.localtime(timezone.now()).date()
+        if now > value:
+            raise serializers.ValidationError("지나간 날부터 설문조사 종료일자 설정을 할 수 없습니다.")
+        return value
+
+    def validate(self, data):
+        survey = self.context.get("survey")
+        if data["end_date"] <= data["start_date"]:
+            raise serializers.ValidationError(
+                "설문조사 종료일자는 설문조사 시작일자 보다 빠를수 없습니다."
+            )
+        return data
+
+
+class PublicSurveySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SetDurations
+        fields = (
+            "pk",
+            "start_date",
+            "end_date",
+            "in_a_day_date",
+        )


### PR DESCRIPTION
# 변경점 👍
설문조사에 쓰일 설문조사 기간을 따로 전역 API로 제작, **추후에 사용될 장소 대여나 예약 등에 사용하기 위함**
 
총 3가지 validation 옵션
- 설문조사 시작일자가 오늘보다 빠른 경우 (악용 가능성 존재하여 구현)
- 설문조사 종료일자가 오늘보다 빠른 경우 (유효하지 않은 설문조사)
- 설문조사 종료일자가 시작일자보다 빠른 경우


# 스크린샷 🖼
![image](https://user-images.githubusercontent.com/81455273/207369525-5fbb39a5-65ba-4fb6-b8e3-406565f6c61a.png)
 
# 비고 ✏
 추가 기능이나 옵션 필요하다면 코멘트 부탁드립니다.